### PR TITLE
fix: support `catalogs:default` when adding new entry

### DIFF
--- a/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.test.ts
@@ -22,6 +22,50 @@ const invalids: InvalidTestCase[] = [
     filename: 'package.json',
     code: JSON.stringify({
       dependencies: {
+        vue: '^3.6.0',
+      },
+    }, null, 2),
+    errors: [
+      { messageId: 'expectCatalog' },
+    ],
+    options: {
+      defaultCatalog: 'default',
+    },
+    async before() {
+      const workspace = getMockedWorkspace()
+      workspace.setContent(`
+        catalogs:
+          default:
+            vue: ^3.6.0
+      `)
+    },
+    async output(value) {
+      expect(value)
+        .toMatchInlineSnapshot(`
+          "{
+            "dependencies": {
+              "vue": "catalog:"
+            }
+          }"
+        `)
+
+      const workspace = getMockedWorkspace()
+      expect(workspace.toString())
+        .toMatchInlineSnapshot(`
+          "catalogs:
+            default:
+              vue: ^3.6.0
+          "
+        `)
+    },
+    async after() {
+      getMockedWorkspace().setContent(``)
+    },
+  },
+  {
+    filename: 'package.json',
+    code: JSON.stringify({
+      dependencies: {
         'react-dom': 'catalog:react-dom',
         'react': '^18.2.0',
       },

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-duplicate-catalog-item.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-duplicate-catalog-item.test.ts
@@ -45,6 +45,28 @@ const invalids: InvalidTestCase[] = [
       },
     ],
   },
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: [
+        'packages/*',
+      ],
+      catalogs: {
+        react: {
+          foo: '^18.2.0',
+        },
+        default: {
+          foo: 'bar',
+        },
+      },
+    }),
+    errors: [
+      {
+        messageId: 'duplicateCatalogItem',
+        data: { name: 'foo', currentCatalog: 'default', existingCatalog: 'react' },
+      },
+    ],
+  },
 ]
 
 runYaml({

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-duplicate-catalog-item.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-duplicate-catalog-item.ts
@@ -55,7 +55,7 @@ export default createEslintRule<Options, MessageIds>({
 
     const catalogs = {
       ...json.catalogs,
-      default: json.catalog,
+      default: json.catalog ?? json.catalogs?.default,
     }
 
     const doc = workspace.getDocument()
@@ -69,7 +69,7 @@ export default createEslintRule<Options, MessageIds>({
 
         if (exists.has(key)) {
           const existingCatalog = exists.get(key)!
-          const node = doc.getIn(catalog === 'default' ? ['catalog', key] : ['catalogs', catalog, key], true)! as YAMLScalar
+          const node = doc.getIn(catalog === 'default' ? (json.catalog ? ['catalog', key] : ['catalogs', catalog, key]) : ['catalogs', catalog, key], true)! as YAMLScalar
           const start = context.sourceCode.getLocFromIndex(node.range![0])
           const end = context.sourceCode.getLocFromIndex(node.range![1])
           context.report({

--- a/packages/pnpm-workspace-yaml/src/index.test.ts
+++ b/packages/pnpm-workspace-yaml/src/index.test.ts
@@ -234,6 +234,23 @@ describe('setPackageNoConflicts', () => {
     `)
   })
 
+  it('should set package in catalogs:default', () => {
+    const input = `
+  catalogs:
+    default:
+      bar: ^1.2.3
+  `
+    const workspace = parsePnpmWorkspaceYaml(input)
+    workspace.setPackageNoConflicts('default', 'foo', '^1.0.0')
+    expect(workspace.toString()).toMatchInlineSnapshot(`
+      "catalogs:
+        default:
+          bar: ^1.2.3
+          foo: ^1.0.0
+      "
+    `)
+  })
+
   it('should set package in named catalog', () => {
     const workspace = parsePnpmWorkspaceYaml('')
     workspace.setPackageNoConflicts('dev', 'foo', '^1.0.0')

--- a/packages/pnpm-workspace-yaml/src/index.ts
+++ b/packages/pnpm-workspace-yaml/src/index.ts
@@ -143,8 +143,9 @@ export function parsePnpmWorkspaceYaml(content: string): PnpmWorkspaceYaml {
   }
 
   function setPackage(catalogName: string, packageName: string, specifier: string): void {
+    const useCatalogsDefault = document.toJSON()?.catalogs?.default !== undefined
     // Simply set the package in the specified catalog, overriding any existing value
-    if (catalogName === 'default') {
+    if (catalogName === 'default' && !useCatalogsDefault) {
       setPath(['catalog', packageName], specifier)
     }
     else {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When auto-fixing a package version and the target catalog is 'default', the `json-enforce-catalog` rule always adds to `pnpm-workspace.yaml#catalog`.

However this is incorrect, as pnpm does not allow having both `catalog` and `catalogs:default` in the workspace file.

<img width="841" height="80" alt="image" src="https://github.com/user-attachments/assets/54fe0196-f4dd-4929-b29c-94de4253aa73" />

This PR adds a simple check when setting packages, to ensure we use `catalogs:default` instead of `catalog` when applicable

### Linked Issues

None.

### Additional context

None.