### PR TITLE
feat(enforce-catalog): add options ignores (#18)

### DIFF
--- a/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.test.ts
@@ -155,6 +155,51 @@ const invalids: InvalidTestCase[] = [
         `)
     },
   },
+  {
+    description: 'Ignores some packages',
+    filename: 'package.json',
+    code: JSON.stringify({
+      dependencies: {
+        react: '^18.2.0',
+      },
+      devDependencies: {
+        'react-native': '^5.0.0',
+        '@types/vscode': '^1.89.0',
+      },
+    }, null, 2),
+    options: [
+      {
+        ignores: ['@types/vscode'],
+      },
+    ],
+    errors: [
+      { messageId: 'expectCatalog' },
+      { messageId: 'expectCatalog' },
+    ],
+    async output(value) {
+      expect(value)
+        .toMatchInlineSnapshot(`
+          "{
+            "dependencies": {
+              "react": "catalog:"
+            },
+            "devDependencies": {
+              "react-native": "catalog:",
+              "@types/vscode": "^1.89.0"
+            }
+          }"
+        `)
+
+      const workspace = getMockedWorkspace()
+      expect(workspace.toString())
+        .toMatchInlineSnapshot(`
+          "catalog:
+            react: ^18.2.0
+            react-native: ^5.0.0
+          "
+        `)
+    },
+  },
 ]
 
 runJson({

--- a/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.ts
@@ -14,6 +14,7 @@ export type Options = [
     reuseExistingCatalog?: boolean
     conflicts?: ConflictStrategy
     fields?: string[]
+    ignores?: string[]
   },
 ]
 
@@ -67,6 +68,12 @@ export default createEslintRule<Options, MessageIds>({
             items: { type: 'string' },
             default: DEFAULT_FIELDS,
           },
+          ignores: {
+            type: 'array',
+            description: 'Ignore certain packages that require version specification',
+            items: { type: 'string' },
+            default: [],
+          },
         },
         additionalProperties: false,
       },
@@ -84,10 +91,11 @@ export default createEslintRule<Options, MessageIds>({
       reuseExistingCatalog = true,
       conflicts = 'new-catalog',
       fields = DEFAULT_FIELDS,
+      ignores = [],
     } = options || {}
 
     for (const { packageName, specifier, property } of iterateDependencies(context, fields)) {
-      if (specifier.startsWith('catalog:'))
+      if (specifier.startsWith('catalog:') || ignores.includes(packageName))
         continue
       if (allowedProtocols?.some(p => specifier.startsWith(p)))
         continue


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This `PR` adds a new `ignores` option to the `json-enforce-catalog` rule, allowing users to exclude specific packages from the version enforcement requirement.

### Linked Issues
<img width="741" height="75" alt="image" src="https://github.com/user-attachments/assets/63829e86-f974-4ece-a863-85dd3b6ae86b" />

closes #18 

### Additional context


```typescript
overrideRules({
    "pnpm/json-enforce-catalog": [
      "error",
      {
        ignores: [
          "@types/vscode"
        ],
      },
    ],
  });
```
<!-- e.g. is there anything you'd like reviewers to focus on? -->
