### PR TITLE
feat(eslint-plugin-pnpm): yaml-valid-packages

### DIFF
--- a/packages/eslint-plugin-pnpm/src/index.ts
+++ b/packages/eslint-plugin-pnpm/src/index.ts
@@ -46,6 +46,7 @@ const configsYaml: Linter.Config[] = [
     rules: {
       'pnpm/yaml-no-unused-catalog-item': 'error',
       'pnpm/yaml-no-duplicate-catalog-item': 'error',
+      'pnpm/yaml-valid-packages': 'error',
     },
   },
 ]

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/index.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/index.ts
@@ -1,7 +1,9 @@
 import noDuplicateCatalogItem from './yaml-no-duplicate-catalog-item'
 import noUnusedCatalogItem from './yaml-no-unused-catalog-item'
+import validPackages from './yaml-valid-packages'
 
 export const rules = {
   'yaml-no-unused-catalog-item': noUnusedCatalogItem,
   'yaml-no-duplicate-catalog-item': noDuplicateCatalogItem,
+  'yaml-valid-packages': validPackages,
 }

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-valid-packages.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-valid-packages.test.ts
@@ -12,6 +12,17 @@ const valids: ValidTestCase[] = [
       ],
     }),
   },
+  // Patterns with trailing slash
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: [
+        'packages/*/',
+      ],
+    }),
+  },
+
+  // Direct path
   {
     filename: 'pnpm-workspace.yaml',
     code: yaml.stringify({

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-valid-packages.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-valid-packages.test.ts
@@ -1,0 +1,107 @@
+import type { InvalidTestCase, ValidTestCase } from 'eslint-vitest-rule-tester'
+import yaml from 'yaml'
+import { runYaml } from '../../utils/_test'
+import rule, { RULE_NAME } from './yaml-valid-packages'
+
+const valids: ValidTestCase[] = [
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: [
+        'packages/*',
+      ],
+    }),
+  },
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: [
+        '.',
+      ],
+    }),
+  },
+  // Direct path (non-glob)
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: [
+        'packages/eslint-plugin-pnpm',
+        'packages/pnpm-workspace-yaml',
+      ],
+    }),
+  },
+]
+
+const invalids: InvalidTestCase[] = [
+  // Invalid types
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: [
+        'packages/*',
+        123,
+        true,
+        null,
+      ],
+    }),
+    errors: [
+      {
+        messageId: 'invalidType',
+        data: { type: 'number' },
+      },
+      {
+        messageId: 'invalidType',
+        data: { type: 'boolean' },
+      },
+      {
+        messageId: 'invalidType',
+        data: { type: 'object' },
+      },
+    ],
+  },
+
+  // No matches (directories don't exist)
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: [
+        'packages/*',
+        'nonexistent/*',
+        'another-missing/*',
+      ],
+    }),
+    errors: [
+      {
+        messageId: 'noMatch',
+        data: { pattern: 'nonexistent/*' },
+      },
+      {
+        messageId: 'noMatch',
+        data: { pattern: 'another-missing/*' },
+      },
+    ],
+  },
+
+  // No matches (directories exist but no package.json)
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: [
+        'test/*',
+      ],
+    }),
+    errors: [
+      {
+        messageId: 'noMatch',
+        data: { pattern: 'test/*' },
+      },
+    ],
+  },
+]
+
+runYaml({
+  name: RULE_NAME,
+  rule,
+  valid: valids,
+  invalid: invalids,
+})

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-valid-packages.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-valid-packages.ts
@@ -1,6 +1,6 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { Scalar as YAMLScalar, YAMLSeq } from 'yaml'
-import { basename, dirname, normalize, resolve } from 'pathe'
+import { basename, dirname, join, normalize, resolve } from 'pathe'
 import { globSync } from 'tinyglobby'
 import { createEslintRule } from '../../utils/create'
 import { getPnpmWorkspace } from '../../utils/workspace'
@@ -74,7 +74,7 @@ export default createEslintRule<Options, MessageIds>({
         continue
       }
 
-      const globMatches = globSync(`${pattern}/package.json`, {
+      const globMatches = globSync(join(pattern, 'package.json'), {
         cwd: root,
         dot: false,
         ignore: ['**/node_modules/**', '**/dist/**', '**/build/**'],

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-valid-packages.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-valid-packages.ts
@@ -1,0 +1,93 @@
+import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
+import type { Scalar as YAMLScalar, YAMLSeq } from 'yaml'
+import { basename, dirname, normalize, resolve } from 'pathe'
+import { globSync } from 'tinyglobby'
+import { createEslintRule } from '../../utils/create'
+import { getPnpmWorkspace } from '../../utils/workspace'
+
+export const RULE_NAME = 'yaml-valid-packages'
+export type MessageIds = 'noMatch' | 'invalidType'
+export type Options = []
+
+function reportError(
+  context: RuleContext<MessageIds, Options>,
+  item: YAMLScalar,
+  messageId: MessageIds,
+  data: Record<string, string>,
+): void {
+  const start = context.sourceCode.getLocFromIndex(item.range![0])
+  const end = context.sourceCode.getLocFromIndex(item.range![1])
+  context.report({
+    loc: { start, end },
+    messageId,
+    data,
+  })
+}
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Ensure all package patterns in `pnpm-workspace.yaml` match at least one directory',
+    },
+    schema: [],
+    messages: {
+      noMatch: 'Package pattern "{{pattern}}" does not match any directories with a package.json file.',
+      invalidType: 'Package pattern must be a string, got {{type}}.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    if (basename(context.filename) !== 'pnpm-workspace.yaml')
+      return {}
+
+    const workspace = getPnpmWorkspace(context)
+    if (!workspace || normalize(workspace.filepath) !== normalize(context.filename))
+      return {}
+
+    if (workspace.hasChanged() || workspace.hasQueue())
+      return {}
+
+    workspace.setContent(context.sourceCode.text)
+    const parsed = workspace.toJSON() || {}
+
+    if (!parsed.packages || !Array.isArray(parsed.packages))
+      return {}
+
+    const doc = workspace.getDocument()
+    const packagesNode = doc.getIn(['packages']) as YAMLSeq | undefined
+
+    if (!packagesNode)
+      return {}
+
+    const root = resolve(dirname(context.filename))
+
+    for (let i = 0; i < parsed.packages.length; i++) {
+      const item = packagesNode.items[i] as YAMLScalar | undefined
+      if (!item?.range)
+        continue
+
+      const pattern = parsed.packages[i]
+      if (typeof pattern !== 'string') {
+        reportError(context, item, 'invalidType', { type: typeof pattern })
+        continue
+      }
+
+      const globMatches = globSync(`${pattern}/package.json`, {
+        cwd: root,
+        dot: false,
+        ignore: ['**/node_modules/**', '**/dist/**', '**/build/**'],
+        absolute: false,
+        expandDirectories: false,
+        onlyFiles: true,
+      }).length
+
+      if (globMatches === 0) {
+        reportError(context, item, 'noMatch', { pattern })
+      }
+    }
+
+    return {}
+  },
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,5 @@
 packages:
-  - playground
-  - docs
   - packages/*
-  - examples/*
 
 ignoreWorkspaceRootCheck: true
 shellEmulator: true


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Adds a new ESLint rule `yaml-valid-packages` that validates the `packages` property in `pnpm-workspace.yaml`.

pnpm silently ignores package patterns that don't match anything, which can lead to confusing situations where developers think a package is included in the workspace but it's actually being ignored. This rule catches these issues at lint time.

### Linked Issues
N/A

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
