### PR TITLE
test(json-enforce-catalog): autofix applied without --fix bug

### DIFF
--- a/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.test.ts
@@ -244,6 +244,31 @@ const invalids: InvalidTestCase[] = [
         `)
     },
   },
+  {
+    description: 'BUG: Should not modify workspace file when linting without --fix',
+    filename: 'package.json',
+    code: JSON.stringify({
+      dependencies: {
+        lodash: '^4.17.21',
+      },
+    }, null, 2),
+    errors: [
+      { messageId: 'expectCatalog' },
+    ],
+    async before() {
+      const workspace = getMockedWorkspace()
+      workspace.setContent(``)
+    },
+    async after() {
+      // Wait for any queued changes to potentially execute
+      await new Promise(resolve => setTimeout(resolve, 1100))
+
+      const workspace = getMockedWorkspace()
+      // BUG: This test should pass, but currently fails because
+      // the workspace file gets modified even without applying fixes
+      expect(workspace.toString()).toBe('')
+    },
+  },
 ]
 
 runJson({


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

The `json-enforce-catalog` rule currently modifies `pnpm-workspace.yaml` even when ESLint is run without the `--fix` flag.

This happens because the rule calls `workspace.queueChange()` at the time the fixer is defined, rather than when the fix is actually applied. I added a test to show that changes are written to disk regardless of whether ESLint is applying fixes.

Unfortunately, it's not straightforward to prevent this. ESLint doesn't expose a clear signal for "in fix mode". For example, in dry-run mode, fixes are reported but not written, making it hard to distinguish reliably.

#### Potential solutions

1. Go into ESLint's source to identify properties that are only read when a fix is actually applied, and turn that property into a getter so we can trigger the patch. This would depend on ESLint's internals, which can change at any time, and it may not even be possible.

2. Set up another rule targeted at `pnpm-workspace.yaml` just for queued fixes from `json-enforce-catalog`. When it receives a queued fix, it applies it. This approach assumes rules run in the same runtime, which may not always hold true since ESLint has recently introduced parallel workers.


<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
