### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-enforce-settings.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-enforce-settings.ts
@@ -27,6 +27,7 @@ export default createEslintRule<Options, MessageIds>({
     schema: [
       {
         type: 'object',
+        additionalProperties: false,
         properties: {
           autofix: {
             type: 'boolean',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

[yaml-enforce-settings](https://github.com/antfu/pnpm-workspace-utils/blob/7d608b8aa8f1c9a2b76ca4a2cc75d96e914268ae/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-enforce-settings.ts#L29) rule currently allows extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in this rule's schema.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
