### PR TITLE
feat: respect workspace config

### DIFF
--- a/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/json-enforce-catalog.ts
@@ -1,6 +1,6 @@
 import { createEslintRule } from '../../utils/create'
 import { iterateDependencies } from '../../utils/iterate'
-import { getPnpmWorkspace } from '../../utils/workspace'
+import { getPnpmWorkspace, isWorkspacePackageJson } from '../../utils/workspace'
 
 export type ConflictStrategy = 'new-catalog' | 'overrides' | 'error'
 
@@ -94,15 +94,15 @@ export default createEslintRule<Options, MessageIds>({
       ignores = [],
     } = options || {}
 
+    const workspace = getPnpmWorkspace(context)
+    if (!workspace || !isWorkspacePackageJson(context.filename, workspace))
+      return {}
+
     for (const { packageName, specifier, property } of iterateDependencies(context, fields)) {
       if (specifier.startsWith('catalog:') || ignores.includes(packageName))
         continue
       if (allowedProtocols?.some(p => specifier.startsWith(p)))
         continue
-
-      const workspace = getPnpmWorkspace(context)
-      if (!workspace)
-        return {}
 
       let targetCatalog = reuseExistingCatalog
         ? (workspace.getPackageCatalogs(packageName)[0] || defaultCatalog)

--- a/packages/eslint-plugin-pnpm/src/rules/json/json-prefer-workspace-settings.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/json-prefer-workspace-settings.ts
@@ -1,6 +1,6 @@
 import { createEslintRule } from '../../utils/create'
 import { getPackageJsonRootNode } from '../../utils/iterate'
-import { getPnpmWorkspace } from '../../utils/workspace'
+import { getPnpmWorkspace, isWorkspacePackageJson } from '../../utils/workspace'
 
 export const RULE_NAME = 'json-prefer-workspace-settings'
 export type MessageIds = 'unexpectedPnpmSettings'
@@ -50,7 +50,7 @@ export default createEslintRule<Options, MessageIds>({
       return {}
 
     const workspace = getPnpmWorkspace(context)
-    if (!workspace)
+    if (!workspace || !isWorkspacePackageJson(context.filename, workspace))
       return {}
 
     context.report({

--- a/packages/eslint-plugin-pnpm/src/rules/json/json-valid-catalog.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/json-valid-catalog.ts
@@ -1,6 +1,6 @@
 import { createEslintRule } from '../../utils/create'
 import { iterateDependencies } from '../../utils/iterate'
-import { getPnpmWorkspace } from '../../utils/workspace'
+import { getPnpmWorkspace, isWorkspacePackageJson } from '../../utils/workspace'
 
 export const RULE_NAME = 'json-valid-catalog'
 export type MessageIds = 'invalidCatalog'
@@ -77,13 +77,13 @@ export default createEslintRule<Options, MessageIds>({
       fields = DEFAULT_FIELDS,
     } = options || {}
 
+    const workspace = getPnpmWorkspace(context)
+    if (!workspace || !isWorkspacePackageJson(context.filename, workspace))
+      return {}
+
     for (const { packageName, specifier, property } of iterateDependencies(context, fields)) {
       if (!specifier.startsWith('catalog:'))
         continue
-
-      const workspace = getPnpmWorkspace(context)
-      if (!workspace)
-        return {}
 
       const currentCatalog = specifier.replace(/^catalog:/, '').trim() || 'default'
       const existingCatalogs = workspace.getPackageCatalogs(packageName)

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-unused-catalog-item.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-unused-catalog-item.test.ts
@@ -66,6 +66,25 @@ const invalids: InvalidTestCase[] = [
   {
     filename: 'pnpm-workspace.yaml',
     code: yaml.stringify({
+      packages: [
+        'packages/*',
+      ],
+      catalogs: {
+        test: {
+          'never-used-package': '*',
+        },
+      },
+    }),
+    errors: [
+      {
+        messageId: 'unusedCatalogItem',
+        data: { catalogItem: 'never-used-package:test' },
+      },
+    ],
+  },
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
       packages: null,
       overrides: {
         foo: 'catalog:prod',

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-unused-catalog-item.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-unused-catalog-item.ts
@@ -1,9 +1,8 @@
 import type { YAMLMap, Pair as YAMLPair } from 'yaml'
 import { existsSync, readFileSync } from 'node:fs'
-import { basename, dirname, normalize, resolve } from 'pathe'
-import { globSync } from 'tinyglobby'
+import { basename, normalize } from 'pathe'
 import { createEslintRule } from '../../utils/create'
-import { getPnpmWorkspace } from '../../utils/workspace'
+import { getPnpmWorkspace, getWorkspacePackageJsonPaths } from '../../utils/workspace'
 
 export const RULE_NAME = 'yaml-no-unused-catalog-item'
 export type MessageIds = 'unusedCatalogItem'
@@ -38,7 +37,6 @@ export default createEslintRule<Options, MessageIds>({
 
     workspace.setContent(context.sourceCode.text)
     const parsed = workspace.toJSON() || {}
-    const root = resolve(dirname(context.filename))
 
     const entries: Map<string, YAMLPair<any, any>> = new Map()
 
@@ -69,25 +67,7 @@ export default createEslintRule<Options, MessageIds>({
     if (entries.size === 0)
       return {}
 
-    const dirs = parsed.packages
-      ? globSync(parsed.packages, {
-          cwd: root,
-          dot: false,
-          ignore: [
-            '**/node_modules/**',
-            '**/dist/**',
-            '**/build/**',
-            '**/dist/**',
-            '**/dist/**',
-          ],
-          absolute: true,
-          expandDirectories: false,
-          onlyDirectories: true,
-        })
-      : []
-    dirs.push(root)
-
-    const packages = dirs.map(dir => resolve(dir, 'package.json'))
+    const packages = Array.from(getWorkspacePackageJsonPaths(workspace))
       .filter(x => existsSync(x))
       .sort()
 

--- a/packages/eslint-plugin-pnpm/src/utils/workspace.test.ts
+++ b/packages/eslint-plugin-pnpm/src/utils/workspace.test.ts
@@ -1,0 +1,68 @@
+import type { PnpmWorkspaceYamlExtended } from './_read'
+import { resolve } from 'pathe'
+import { parsePnpmWorkspaceYaml } from 'pnpm-workspace-yaml'
+import { expect, it } from 'vitest'
+import { getWorkspacePackageJsonPaths, isWorkspacePackageJson } from './workspace'
+
+function createWorkspace(content: string): PnpmWorkspaceYamlExtended {
+  const workspace = parsePnpmWorkspaceYaml(content)
+  return {
+    filepath: 'pnpm-workspace.yaml',
+    lastRead: Date.now(),
+    ...workspace,
+    hasQueue: () => false,
+    queueChange: () => {},
+  }
+}
+
+it('matches package.json files covered by workspace packages patterns and always includes root', () => {
+  const workspace = createWorkspace(`
+packages:
+  - packages/*
+`)
+
+  expect(isWorkspacePackageJson('packages/eslint-plugin-pnpm/package.json', workspace)).toBe(true)
+  expect(isWorkspacePackageJson('packages/pnpm-workspace-yaml/package.json', workspace)).toBe(true)
+  expect(isWorkspacePackageJson('package.json', workspace)).toBe(true)
+  expect(isWorkspacePackageJson('examples/demo/package.json', workspace)).toBe(false)
+})
+
+it('respects negated package patterns', () => {
+  const workspace = createWorkspace(`
+packages:
+  - packages/*
+  - '!packages/pnpm-workspace-yaml'
+`)
+
+  const packageJsonPaths = getWorkspacePackageJsonPaths(workspace)
+
+  expect(packageJsonPaths.size).toBe(2)
+  expect(isWorkspacePackageJson('package.json', workspace)).toBe(true)
+  expect(isWorkspacePackageJson('packages/eslint-plugin-pnpm/package.json', workspace)).toBe(true)
+  expect(isWorkspacePackageJson('packages/pnpm-workspace-yaml/package.json', workspace)).toBe(false)
+})
+
+it('includes root and subpackages when packages is missing', () => {
+  const withoutPackages = createWorkspace(`
+catalog:
+  foo: ^1.0.0
+`)
+
+  expect(isWorkspacePackageJson('package.json', withoutPackages)).toBe(true)
+  expect(isWorkspacePackageJson('packages/eslint-plugin-pnpm/package.json', withoutPackages)).toBe(true)
+  expect(isWorkspacePackageJson('packages/pnpm-workspace-yaml/package.json', withoutPackages)).toBe(true)
+})
+
+it('falls back to the root package when packages is invalid', () => {
+  const withInvalidPackages = createWorkspace(`
+packages:
+  - packages/*
+  - {}
+`)
+
+  expect(getWorkspacePackageJsonPaths(withInvalidPackages)).toEqual(new Set([
+    resolve('package.json'),
+  ]))
+  expect(isWorkspacePackageJson('package.json', withInvalidPackages)).toBe(true)
+  expect(isWorkspacePackageJson('packages/eslint-plugin-pnpm/package.json', withInvalidPackages)).toBe(false)
+})

--- a/packages/eslint-plugin-pnpm/src/utils/workspace.ts
+++ b/packages/eslint-plugin-pnpm/src/utils/workspace.ts
@@ -85,7 +85,7 @@ function globPackageJsonPaths(
   includeGlobs: string[],
   excludeGlobs: string[],
 ): Set<string> {
-  const cacheKey = [root, ...includeGlobs, '::', ...excludeGlobs].join('\0')
+  const cacheKey = JSON.stringify({ root, includeGlobs, excludeGlobs })
   const cached = packageJsonPathCache.get(cacheKey)
   if (cached)
     return cached

--- a/packages/eslint-plugin-pnpm/src/utils/workspace.ts
+++ b/packages/eslint-plugin-pnpm/src/utils/workspace.ts
@@ -1,9 +1,18 @@
 import type { RuleContext } from '@typescript-eslint/utils/ts-eslint'
 import type { PnpmWorkspaceYamlExtended } from './_read'
+import { dirname, join, normalize, resolve } from 'pathe'
+import { globSync } from 'tinyglobby'
 import { createPnpmWorkspace, findPnpmWorkspace, readPnpmWorkspace } from './_read'
 
 const WORKSPACE_CACHE_TIME = 10_000
+const PACKAGE_JSON_GLOB_IGNORE = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/build/**',
+]
+
 const workspaces: Record<string, PnpmWorkspaceYamlExtended | undefined> = {}
+const packageJsonPathCache = new Map<string, Set<string>>()
 
 export function getPnpmWorkspace(
   context: RuleContext<any, any>,
@@ -28,4 +37,95 @@ export function getPnpmWorkspace(
     workspaces[workspacePath] = workspace
   }
   return workspace
+}
+
+export function getWorkspacePackageJsonPaths(workspace: PnpmWorkspaceYamlExtended): Set<string> {
+  const packages = workspace.toJSON()?.packages
+  const root = resolve(dirname(workspace.filepath))
+  const rootPackageJson = normalize(resolve(root, 'package.json'))
+
+  if (packages === undefined) {
+    return new Set([
+      rootPackageJson,
+      ...globPackageJsonPaths(root, ['**/package.json'], PACKAGE_JSON_GLOB_IGNORE),
+    ])
+  }
+  if (!Array.isArray(packages))
+    return new Set([rootPackageJson])
+
+  const packageJsonGlobs = getPackageJsonPatterns(packages)
+  if (!packageJsonGlobs)
+    return new Set([rootPackageJson])
+
+  return new Set([
+    rootPackageJson,
+    ...globPackageJsonPaths(root, packageJsonGlobs.include, packageJsonGlobs.exclude),
+  ])
+}
+
+function getPackageJsonPatterns(packages: string[]): { include: string[], exclude: string[] } | undefined {
+  const include: string[] = []
+  const exclude = [...PACKAGE_JSON_GLOB_IGNORE]
+
+  for (const pattern of packages) {
+    if (typeof pattern !== 'string')
+      return undefined
+
+    if (pattern.startsWith('!'))
+      exclude.push(toPackageJsonGlob(pattern.slice(1)))
+    else
+      include.push(toPackageJsonGlob(pattern))
+  }
+
+  return { include, exclude }
+}
+
+function globPackageJsonPaths(
+  root: string,
+  includeGlobs: string[],
+  excludeGlobs: string[],
+): Set<string> {
+  const cacheKey = [root, ...includeGlobs, '::', ...excludeGlobs].join('\0')
+  const cached = packageJsonPathCache.get(cacheKey)
+  if (cached)
+    return cached
+
+  const paths = new Set<string>()
+  if (includeGlobs.length === 0) {
+    packageJsonPathCache.set(cacheKey, paths)
+    return paths
+  }
+
+  const packageJsonPaths = globSync(includeGlobs, {
+    cwd: root,
+    dot: false,
+    ignore: excludeGlobs,
+    absolute: true,
+    expandDirectories: false,
+    onlyFiles: true,
+  })
+
+  for (const path of packageJsonPaths)
+    paths.add(normalize(path))
+
+  packageJsonPathCache.set(cacheKey, paths)
+  return paths
+}
+
+export function isWorkspacePackageJson(
+  filename: string,
+  workspace: PnpmWorkspaceYamlExtended,
+): boolean {
+  if (!filename.endsWith('package.json'))
+    return false
+
+  const root = resolve(dirname(workspace.filepath))
+  const target = normalize(resolve(root, filename))
+  return getWorkspacePackageJsonPaths(workspace).has(target)
+}
+
+function toPackageJsonGlob(pattern: string): string {
+  return pattern.endsWith('package.json')
+    ? pattern
+    : join(pattern, 'package.json')
 }


### PR DESCRIPTION
- [x] <- Keep this line and put an `x` between the brackts.

### Description

This PR makes workspace `package.json` resolution follow `pnpm-workspace.yaml` instead of treating any `package.json` under the nearest workspace root as a workspace package.