### PR TITLE
feat(eslint-plugin-pnpm): add `json-prefer-pnpm-overrides` rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "yaml": "catalog:prod",
     "yaml-eslint-parser": "catalog:prod"
   },
-  "resolutions": {
-    "eslint-plugin-pnpm": "workspace:*"
-  },
   "simple-git-hooks": {
     "pre-commit": "pnpm lint-staged"
   },

--- a/packages/eslint-plugin-pnpm/src/index.ts
+++ b/packages/eslint-plugin-pnpm/src/index.ts
@@ -27,6 +27,7 @@ const configsJson: Linter.Config[] = [
     },
     rules: {
       'pnpm/json-enforce-catalog': 'error',
+      'pnpm/json-prefer-pnpm-overrides': 'warn',
       'pnpm/json-valid-catalog': 'error',
       'pnpm/json-prefer-workspace-settings': 'error',
     },

--- a/packages/eslint-plugin-pnpm/src/rules/json/index.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/index.ts
@@ -1,9 +1,11 @@
 import enforceCatalog from './json-enforce-catalog'
+import preferPnpmOverrides from './json-prefer-pnpm-overrides'
 import preferWorkspaceSettings from './json-prefer-workspace-settings'
 import validCatalog from './json-valid-catalog'
 
 export const rules = {
   'json-enforce-catalog': enforceCatalog,
+  'json-prefer-pnpm-overrides': preferPnpmOverrides,
   'json-valid-catalog': validCatalog,
   'json-prefer-workspace-settings': preferWorkspaceSettings,
 }

--- a/packages/eslint-plugin-pnpm/src/rules/json/json-prefer-pnpm-overrides.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/json-prefer-pnpm-overrides.test.ts
@@ -1,0 +1,55 @@
+import type { InvalidTestCase, ValidTestCase } from 'eslint-vitest-rule-tester'
+import { runJson } from '../../utils/_test'
+import rule, { RULE_NAME } from './json-prefer-pnpm-overrides'
+
+const valids: ValidTestCase[] = [
+  {
+    filename: 'package.json',
+    code: JSON.stringify({
+      dependencies: { react: '^18.0.0' },
+    }, null, 2),
+  },
+  {
+    filename: 'package.json',
+    code: JSON.stringify({
+      pnpm: {
+        overrides: { lodash: '^4.17.21' },
+      },
+    }, null, 2),
+  },
+]
+
+const invalids: InvalidTestCase[] = [
+  {
+    filename: 'package.json',
+    code: JSON.stringify({
+      resolutions: {
+        lodash: '^4.17.21',
+      },
+    }, null, 2),
+    errors: [
+      { messageId: 'preferPnpmOverrides' },
+    ],
+  },
+  {
+    filename: 'package.json',
+    code: JSON.stringify({
+      pnpm: {
+        overrides: { react: '^18.0.0' },
+      },
+      resolutions: {
+        lodash: '^4.17.21',
+      },
+    }, null, 2),
+    errors: [
+      { messageId: 'preferPnpmOverrides' },
+    ],
+  },
+]
+
+runJson({
+  name: RULE_NAME,
+  rule,
+  valid: valids,
+  invalid: invalids,
+})

--- a/packages/eslint-plugin-pnpm/src/rules/json/json-prefer-pnpm-overrides.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/json/json-prefer-pnpm-overrides.ts
@@ -1,0 +1,83 @@
+import { createEslintRule } from '../../utils/create'
+import { getPackageJsonRootNode } from '../../utils/iterate'
+
+export const RULE_NAME = 'json-prefer-pnpm-overrides'
+export type MessageIds = 'preferPnpmOverrides'
+export type Options = [
+  {
+    autofix?: boolean
+  },
+]
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'layout',
+    docs: {
+      description:
+        'Prefer using `pnpm.overrides` in `package.json` (or overrides in `pnpm-workspace.yaml`) instead of `resolutions`.',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          autofix: {
+            type: 'boolean',
+            description: 'Whether to autofix by renaming `resolutions` to `pnpm.overrides`',
+            default: true,
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      preferPnpmOverrides:
+        'Use `pnpm.overrides` instead of `resolutions`. See https://pnpm.io/package_json#pnpmoverrides.',
+    },
+  },
+  defaultOptions: [{}],
+  create(context, [options = {}]) {
+    const {
+      autofix = true,
+    } = options || {}
+
+    const root = getPackageJsonRootNode(context)
+    if (!root)
+      return {}
+
+    const resolutionsNode = root.properties.find(
+      property =>
+        property.key.type === 'JSONLiteral' && property.key.value === 'resolutions',
+    )
+    if (!resolutionsNode)
+      return {}
+
+    context.report({
+      node: resolutionsNode as any,
+      messageId: 'preferPnpmOverrides',
+      fix: autofix
+        ? (fixer) => {
+            const json = JSON.parse(context.sourceCode.text)
+            const resolutions = json.resolutions
+            const pnpm = json.pnpm || {}
+
+            // Merge resolutions into pnpm.overrides
+            pnpm.overrides = {
+              ...pnpm.overrides,
+              ...resolutions,
+            }
+
+            const updatedJson = { ...json }
+            delete updatedJson.resolutions
+            updatedJson.pnpm = pnpm
+
+            const output = JSON.stringify(updatedJson, null, 2)
+            return fixer.replaceText(root as any, output)
+          }
+        : undefined,
+    })
+
+    return {}
+  },
+})

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,3 +42,5 @@ catalogs:
 onlyBuiltDependencies:
   - esbuild
   - simple-git-hooks
+overrides:
+  eslint-plugin-pnpm: workspace:*


### PR DESCRIPTION
Closes #4

Adds a new ESLint rule `json-prefer-pnpm-overrides` that detects the `resolutions` field in `package.json` and suggests using `pnpm.overrides` instead.

- Reports a warning when `resolutions` is found
- Autofix: moves entries from `resolutions` into `pnpm.overrides`
- Merges with existing `pnpm.overrides` if present
- Configurable `autofix` option (default: true)