### PR TITLE
feat: add YAML catalog sorting rule

### DIFF
--- a/packages/eslint-plugin-pnpm/README.md
+++ b/packages/eslint-plugin-pnpm/README.md
@@ -35,6 +35,39 @@ export default [
 ]
 ```
 
+### Optional Catalog Sorting
+
+Catalog sorting is not enabled by default. Add this after `...configs.yaml`:
+
+```js
+export default [
+  ...configs.yaml,
+  {
+    files: ['pnpm-workspace.yaml'],
+    rules: {
+      'pnpm/yaml-sort-catalogs': 'error',
+    },
+  },
+]
+```
+
+It sorts catalog names by default. To also sort package names inside catalogs:
+
+```js
+export default [
+  ...configs.yaml,
+  {
+    files: ['pnpm-workspace.yaml'],
+    rules: {
+      'pnpm/yaml-sort-catalogs': ['error', {
+        sortCatalogNames: true,
+        sortCatalogItems: true,
+      }],
+    },
+  },
+]
+```
+
 ### Manual Configuration
 
 ```js
@@ -97,6 +130,7 @@ export default [
 - [`yaml-no-duplicate-catalog-item`](./src/rules/yaml/yaml-no-duplicate-catalog-item.ts) - Disallow duplicate catalog items
 - [`yaml-valid-packages`](./src/rules/yaml/yaml-valid-packages.ts) - Ensure package patterns match directories with package.json
 - [`yaml-enforce-settings`](./src/rules/yaml/yaml-enforce-settings.ts) - Enforce settings in `pnpm-workspace.yaml`
+- [`yaml-sort-catalogs`](./src/rules/yaml/yaml-sort-catalogs.ts) - Enforce sorted catalogs in `pnpm-workspace.yaml`
 
 ## Settings
 

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/index.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/index.ts
@@ -1,6 +1,7 @@
 import enforceSettings from './yaml-enforce-settings'
 import noDuplicateCatalogItem from './yaml-no-duplicate-catalog-item'
 import noUnusedCatalogItem from './yaml-no-unused-catalog-item'
+import sortCatalogs from './yaml-sort-catalogs'
 import validPackages from './yaml-valid-packages'
 
 export const rules = {
@@ -8,4 +9,5 @@ export const rules = {
   'yaml-no-duplicate-catalog-item': noDuplicateCatalogItem,
   'yaml-valid-packages': validPackages,
   'yaml-enforce-settings': enforceSettings,
+  'yaml-sort-catalogs': sortCatalogs,
 }

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-sort-catalogs.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-sort-catalogs.test.ts
@@ -1,0 +1,212 @@
+import type { InvalidTestCase, ValidTestCase } from 'eslint-vitest-rule-tester'
+import { expect } from 'vitest'
+import { runYaml } from '../../utils/_test'
+import rule, { RULE_NAME } from './yaml-sort-catalogs'
+
+const valids: ValidTestCase[] = [
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: `catalogs:
+  dev:
+    typescript: ^6.0.0
+  prod:
+    yaml: ^2.0.0
+  test:
+    vitest: ^4.0.0
+`,
+  },
+  {
+    name: 'does not sort catalog items by default',
+    filename: 'pnpm-workspace.yaml',
+    code: `catalogs:
+  dev:
+    typescript: ^6.0.0
+    eslint: ^10.0.0
+`,
+  },
+  {
+    name: 'allows disabling all sorting',
+    filename: 'pnpm-workspace.yaml',
+    code: `catalogs:
+  test:
+    vitest: ^4.0.0
+  dev:
+    typescript: ^6.0.0
+`,
+    options: [{ sortCatalogNames: false, sortCatalogItems: false }],
+  },
+]
+
+const invalids: InvalidTestCase[] = [
+  {
+    name: 'sorts catalog names by default',
+    filename: 'pnpm-workspace.yaml',
+    code: `packages:
+  - packages/*
+catalogs:
+  test:
+    vitest: ^4.0.0
+  dev:
+    typescript: ^6.0.0
+  prod:
+    yaml: ^2.0.0
+`,
+    errors: [
+      {
+        messageId: 'unsortedCatalogs',
+      },
+    ],
+    output: `packages:
+  - packages/*
+catalogs:
+  dev:
+    typescript: ^6.0.0
+  prod:
+    yaml: ^2.0.0
+  test:
+    vitest: ^4.0.0
+`,
+  },
+  {
+    name: 'sorts catalog items when enabled',
+    filename: 'pnpm-workspace.yaml',
+    code: `catalog:
+  vite: ^8.0.0
+  '@types/node': ^25.0.0
+catalogs:
+  dev:
+    typescript: ^6.0.0
+    eslint: ^10.0.0
+  prod:
+    yaml: ^2.0.0
+`,
+    options: [{ sortCatalogNames: false, sortCatalogItems: true }],
+    errors: [
+      {
+        messageId: 'unsortedCatalogs',
+      },
+    ],
+    output: `catalog:
+  '@types/node': ^25.0.0
+  vite: ^8.0.0
+catalogs:
+  dev:
+    eslint: ^10.0.0
+    typescript: ^6.0.0
+  prod:
+    yaml: ^2.0.0
+`,
+  },
+  {
+    name: 'sorts catalog names and items together',
+    filename: 'pnpm-workspace.yaml',
+    code: `catalogs:
+  test:
+    vitest: ^4.0.0
+    '@vitest/ui': ^4.0.0
+  dev:
+    typescript: ^6.0.0
+    '@types/node': ^25.0.0
+    eslint: ^10.0.0
+`,
+    options: [{ sortCatalogNames: true, sortCatalogItems: true }],
+    errors: [
+      {
+        messageId: 'unsortedCatalogs',
+      },
+    ],
+    output: `catalogs:
+  dev:
+    '@types/node': ^25.0.0
+    eslint: ^10.0.0
+    typescript: ^6.0.0
+  test:
+    '@vitest/ui': ^4.0.0
+    vitest: ^4.0.0
+`,
+  },
+  {
+    name: 'sorts scoped and unscoped package names',
+    filename: 'pnpm-workspace.yaml',
+    code: `catalogs:
+  dev:
+    vite: ^8.0.0
+    '@types/node': ^25.0.0
+    eslint: ^10.0.0
+`,
+    options: [{ sortCatalogNames: false, sortCatalogItems: true }],
+    errors: [
+      {
+        messageId: 'unsortedCatalogs',
+      },
+    ],
+    output: `catalogs:
+  dev:
+    '@types/node': ^25.0.0
+    eslint: ^10.0.0
+    vite: ^8.0.0
+`,
+  },
+  {
+    name: 'can keep default catalog first',
+    filename: 'pnpm-workspace.yaml',
+    code: `catalogs:
+  prod:
+    yaml: ^2.0.0
+  default:
+    react: ^19.0.0
+  dev:
+    typescript: ^6.0.0
+`,
+    options: [{ defaultCatalogPosition: 'first' }],
+    errors: [
+      {
+        messageId: 'unsortedCatalogs',
+      },
+    ],
+    output: `catalogs:
+  default:
+    react: ^19.0.0
+  dev:
+    typescript: ^6.0.0
+  prod:
+    yaml: ^2.0.0
+`,
+  },
+  {
+    name: 'preserves comments with sorted catalog pairs',
+    filename: 'pnpm-workspace.yaml',
+    code: `catalogs:
+  # test tools
+  test:
+    vitest: ^4.0.0
+  # development tools
+  dev:
+    typescript: ^6.0.0
+`,
+    errors: [
+      {
+        messageId: 'unsortedCatalogs',
+      },
+    ],
+    output: (out) => {
+      expect(out).toMatchInlineSnapshot(`
+        "catalogs:
+          # development tools
+          dev:
+            typescript: ^6.0.0
+          # test tools
+          test:
+            vitest: ^4.0.0
+        "
+      `)
+    },
+  },
+]
+
+runYaml({
+  name: RULE_NAME,
+  rule,
+  valid: valids,
+  invalid: invalids,
+})

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-sort-catalogs.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-sort-catalogs.ts
@@ -1,0 +1,186 @@
+import type { YAMLMap, Pair as YAMLPair } from 'yaml'
+import { basename, normalize } from 'pathe'
+import { parseDocument } from 'yaml'
+import { createEslintRule } from '../../utils/create'
+import { getPnpmWorkspace } from '../../utils/workspace'
+
+export const RULE_NAME = 'yaml-sort-catalogs'
+export type MessageIds = 'unsortedCatalogs'
+export type Options = [
+  {
+    sortCatalogNames?: boolean
+    sortCatalogItems?: boolean
+    defaultCatalogPosition?: 'natural' | 'first' | 'last'
+  },
+]
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'layout',
+    docs: {
+      description: 'Enforce sorted catalogs in `pnpm-workspace.yaml`',
+    },
+    fixable: 'code',
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          sortCatalogNames: {
+            type: 'boolean',
+            description: 'Whether to sort catalog names under `catalogs`.',
+            default: true,
+          },
+          sortCatalogItems: {
+            type: 'boolean',
+            description: 'Whether to sort package names inside `catalog` and each named catalog.',
+            default: false,
+          },
+          defaultCatalogPosition: {
+            type: 'string',
+            enum: ['natural', 'first', 'last'],
+            description: 'Where to place the `default` named catalog when sorting catalog names.',
+            default: 'natural',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      unsortedCatalogs: 'Catalogs in `pnpm-workspace.yaml` should be sorted.',
+    },
+  },
+  defaultOptions: [
+    {
+      sortCatalogNames: true,
+      sortCatalogItems: false,
+      defaultCatalogPosition: 'natural',
+    },
+  ],
+  create(context, [options = {}]) {
+    if (basename(context.filename) !== 'pnpm-workspace.yaml')
+      return {}
+
+    const workspace = getPnpmWorkspace(context)
+    if (!workspace || normalize(workspace.filepath) !== normalize(context.filename))
+      return {}
+
+    if (workspace.hasChanged() || workspace.hasQueue())
+      return {}
+
+    const {
+      sortCatalogNames = true,
+      sortCatalogItems = false,
+      defaultCatalogPosition = 'natural',
+    } = options
+
+    if (!sortCatalogNames && !sortCatalogItems)
+      return {}
+
+    const sorted = sortCatalogs(context.sourceCode.text, {
+      sortCatalogNames,
+      sortCatalogItems,
+      defaultCatalogPosition,
+    })
+
+    if (!sorted || sorted === context.sourceCode.text)
+      return {}
+
+    context.report({
+      loc: {
+        start: context.sourceCode.getLocFromIndex(0),
+        end: context.sourceCode.getLocFromIndex(context.sourceCode.text.length),
+      },
+      messageId: 'unsortedCatalogs',
+      fix: fixer => fixer.replaceTextRange([0, context.sourceCode.text.length], sorted),
+    })
+
+    return {}
+  },
+})
+
+function sortCatalogs(
+  code: string,
+  options: Required<NonNullable<Options[0]>>,
+): string | undefined {
+  const doc = parseDocument(code)
+  let changed = false
+
+  if (options.sortCatalogItems) {
+    const catalog = doc.getIn(['catalog'], true) as YAMLMap | undefined
+    if (sortMap(catalog))
+      changed = true
+  }
+
+  const catalogs = doc.getIn(['catalogs'], true) as YAMLMap | undefined
+  if (catalogs) {
+    if (options.sortCatalogItems) {
+      for (const item of catalogs.items) {
+        if (sortMap(item.value as YAMLMap | undefined))
+          changed = true
+      }
+    }
+
+    if (options.sortCatalogNames && sortMap(catalogs, options.defaultCatalogPosition))
+      changed = true
+  }
+
+  return changed ? doc.toString() : undefined
+}
+
+function sortMap(
+  map: YAMLMap | undefined,
+  defaultCatalogPosition: 'natural' | 'first' | 'last' = 'natural',
+): boolean {
+  if (!map?.items || map.items.length < 2)
+    return false
+
+  const sorted = [...map.items].sort((a, b) => comparePairKeys(a, b, defaultCatalogPosition))
+  if (sorted.every((item, index) => item === map.items[index]))
+    return false
+
+  moveLeadingCommentToFirstItem(map)
+  map.items = sorted
+  return true
+}
+
+function moveLeadingCommentToFirstItem(map: YAMLMap): void {
+  if (!map.commentBefore)
+    return
+
+  const first = map.items[0]
+  const key = first?.key
+  if (!key || typeof key !== 'object')
+    return
+
+  const node = key as { commentBefore?: string }
+  node.commentBefore = node.commentBefore
+    ? `${map.commentBefore}\n${node.commentBefore}`
+    : map.commentBefore
+  map.commentBefore = undefined
+}
+
+function comparePairKeys(
+  a: YAMLPair<unknown, unknown>,
+  b: YAMLPair<unknown, unknown>,
+  defaultCatalogPosition: 'natural' | 'first' | 'last',
+): number {
+  const left = getKeyValue(a)
+  const right = getKeyValue(b)
+
+  if (defaultCatalogPosition !== 'natural' && left !== right) {
+    if (left === 'default')
+      return defaultCatalogPosition === 'first' ? -1 : 1
+    if (right === 'default')
+      return defaultCatalogPosition === 'first' ? 1 : -1
+  }
+
+  return left.localeCompare(right)
+}
+
+function getKeyValue(pair: YAMLPair<unknown, unknown>): string {
+  const key = pair.key
+  if (key && typeof key === 'object' && 'value' in key)
+    return String(key.value)
+  return String(key)
+}


### PR DESCRIPTION
Add an opt-in `yaml-sort-catalogs` rule for `pnpm-workspace.yaml`.

### 🔗 Linked issue

N/A

### 🧭 Context

Catalog ordering is a style preference, but keeping large `catalogs` sections sorted can make workspace files easier to scan and review.

### 📚 Description

This PR adds `pnpm/yaml-sort-catalogs` as an opt-in YAML rule.
By default, the rule sorts catalog names only. It can also sort package names inside `catalog` and named catalogs with `sortCatalogItems: true`.
The rule is not included in the default YAML config, so existing users are unaffected unless they enable it explicitly.