### PR TITLE
Normalize package bugs metadata

### DIFF
--- a/packages/eslint-plugin-pnpm/package.json
+++ b/packages/eslint-plugin-pnpm/package.json
@@ -27,7 +27,9 @@
     "url": "git+https://github.com/antfu/pnpm-workspace-utils.git",
     "directory": "packages/eslint-plugin-pnpm"
   },
-  "bugs": "https://github.com/antfu/pnpm-workspace-utils/issues",
+  "bugs": {
+    "url": "https://github.com/antfu/pnpm-workspace-utils/issues"
+  },
   "keywords": [
     "eslint-plugin",
     "pnpm"

--- a/packages/pnpm-workspace-yaml/package.json
+++ b/packages/pnpm-workspace-yaml/package.json
@@ -27,7 +27,9 @@
     "url": "git+https://github.com/antfu/pnpm-workspace-utils.git",
     "directory": "packages/pnpm-workspace-yaml"
   },
-  "bugs": "https://github.com/antfu/pnpm-workspace-utils/issues",
+  "bugs": {
+    "url": "https://github.com/antfu/pnpm-workspace-utils/issues"
+  },
   "keywords": [
     "pnpm"
   ],


### PR DESCRIPTION
### Description

Normalizes the `bugs` metadata for the two published packages so package metadata consumers can read the issue tracker from `bugs.url` consistently.

Updated packages:

- `eslint-plugin-pnpm`
- `pnpm-workspace-yaml`

This does not change runtime code, dependencies, exports, versions, or build output.

### Validation

- Parsed both package manifests with Node and asserted `bugs.url`
- `npm pack --dry-run --ignore-scripts --json` in `packages/eslint-plugin-pnpm`
- `npm pack --dry-run --ignore-scripts --json` in `packages/pnpm-workspace-yaml`
- `git diff --check`