### PR TITLE
feat(eslint): add yaml-require-minimum-release-age rule

### DIFF
--- a/packages/eslint-plugin-pnpm/src/rules/yaml/index.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/index.ts
@@ -1,6 +1,7 @@
 import enforceSettings from './yaml-enforce-settings'
 import noDuplicateCatalogItem from './yaml-no-duplicate-catalog-item'
 import noUnusedCatalogItem from './yaml-no-unused-catalog-item'
+import requireMinimumReleaseAge from './yaml-require-minimum-release-age'
 import validPackages from './yaml-valid-packages'
 
 export const rules = {
@@ -8,4 +9,5 @@ export const rules = {
   'yaml-no-duplicate-catalog-item': noDuplicateCatalogItem,
   'yaml-valid-packages': validPackages,
   'yaml-enforce-settings': enforceSettings,
+  'yaml-require-minimum-release-age': requireMinimumReleaseAge,
 }

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-require-minimum-release-age.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-require-minimum-release-age.test.ts
@@ -1,0 +1,90 @@
+import type { InvalidTestCase, ValidTestCase } from 'eslint-vitest-rule-tester'
+import yaml from 'yaml'
+import { runYaml } from '../../utils/_test'
+import rule, { RULE_NAME } from './yaml-require-minimum-release-age'
+
+const valids: ValidTestCase[] = [
+  // minimumReleaseAge set with a positive number
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: ['packages/*'],
+      minimumReleaseAge: 1000 * 60 * 60 * 24 * 3, // 3 days in ms
+    }),
+  },
+  // minimumReleaseAge set with 1
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: ['packages/*'],
+      minimumReleaseAge: 1,
+    }),
+  },
+  // Not pnpm-workspace.yaml - should be ignored
+  {
+    filename: 'package.json',
+    code: JSON.stringify({ name: 'foo' }),
+  },
+]
+
+const invalids: InvalidTestCase[] = [
+  {
+    name: 'minimumReleaseAge missing',
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: ['packages/*'],
+    }),
+    errors: [
+      { messageId: 'missing' },
+    ],
+  },
+  {
+    name: 'minimumReleaseAge is 0',
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: ['packages/*'],
+      minimumReleaseAge: 0,
+    }),
+    errors: [
+      {
+        messageId: 'invalid',
+        data: { value: '0' },
+      },
+    ],
+  },
+  {
+    name: 'minimumReleaseAge is negative',
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: ['packages/*'],
+      minimumReleaseAge: -100,
+    }),
+    errors: [
+      {
+        messageId: 'invalid',
+        data: { value: '-100' },
+      },
+    ],
+  },
+  {
+    name: 'minimumReleaseAge is null',
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: ['packages/*'],
+      minimumReleaseAge: null,
+    }),
+    errors: [
+      {
+        messageId: 'invalid',
+        data: { value: 'null' },
+      },
+    ],
+  },
+]
+
+runYaml({
+  name: RULE_NAME,
+  rule,
+  valid: valids,
+  invalid: invalids,
+})

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-require-minimum-release-age.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-require-minimum-release-age.ts
@@ -1,0 +1,67 @@
+import type { YAMLMap, Scalar as YAMLScalar } from 'yaml'
+import { basename, normalize } from 'pathe'
+import { createEslintRule } from '../../utils/create'
+import { getPnpmWorkspace } from '../../utils/workspace'
+
+export const RULE_NAME = 'yaml-require-minimum-release-age'
+export type MessageIds = 'missing' | 'invalid'
+export type Options = []
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Require `minimumReleaseAge` to be set in `pnpm-workspace.yaml`',
+    },
+    schema: [],
+    messages: {
+      missing: '`minimumReleaseAge` is not set in `pnpm-workspace.yaml`. Consider setting it to reduce the risk of installing compromised packages.',
+      invalid: '`minimumReleaseAge` in `pnpm-workspace.yaml` must be a positive number, got {{value}}.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    if (basename(context.filename) !== 'pnpm-workspace.yaml')
+      return {}
+
+    const workspace = getPnpmWorkspace(context)
+    if (!workspace || normalize(workspace.filepath) !== normalize(context.filename))
+      return {}
+
+    if (workspace.hasChanged() || workspace.hasQueue())
+      return {}
+
+    workspace.setContent(context.sourceCode.text)
+    const parsed: any = workspace.toJSON() || {}
+    const doc = workspace.getDocument()
+
+    if (!Object.hasOwn(parsed, 'minimumReleaseAge')) {
+      context.report({
+        loc: {
+          start: context.sourceCode.getLocFromIndex(0),
+          end: context.sourceCode.getLocFromIndex(0),
+        },
+        messageId: 'missing',
+      })
+      return {}
+    }
+
+    const value = parsed.minimumReleaseAge
+    if (typeof value !== 'number' || value <= 0) {
+      const node = doc.getIn(['minimumReleaseAge'], true) as YAMLScalar | YAMLMap | undefined
+      const start = node?.range?.[0] ?? 0
+      const end = node?.range?.[1] ?? 0
+      context.report({
+        loc: {
+          start: context.sourceCode.getLocFromIndex(start),
+          end: context.sourceCode.getLocFromIndex(end),
+        },
+        messageId: 'invalid',
+        data: { value: JSON.stringify(value) },
+      })
+    }
+
+    return {}
+  },
+})


### PR DESCRIPTION
## Linked Issues

Closes #24

## Context

pnpm v10.16 introduced the `minimumReleaseAge` setting in `pnpm-workspace.yaml` to delay dependency updates, reducing the risk of installing compromised packages. This rule enforces that the setting is present and valid.

## Description

Add a new ESLint rule `yaml-require-minimum-release-age` that:

- Reports when `minimumReleaseAge` is not set in `pnpm-workspace.yaml`
- Reports when `minimumReleaseAge` is set to an invalid value (non-positive number, null, etc.)
- Follows the existing naming conventions (`yaml-` prefix) and patterns used by other yaml rules in the plugin