### PR TITLE
feat: add `yaml-no-anonymous-catalog` rule

### DIFF
--- a/packages/eslint-plugin-pnpm/README.md
+++ b/packages/eslint-plugin-pnpm/README.md
@@ -78,6 +78,7 @@ export default [
       'pnpm/yaml-no-unused-catalog-item': 'error',
       'pnpm/yaml-no-duplicate-catalog-item': 'error',
       'pnpm/yaml-valid-packages': 'error',
+      'pnpm/yaml-no-anonymous-catalog': 'error',
     },
   },
 ]
@@ -95,6 +96,7 @@ export default [
 
 - [`yaml-no-unused-catalog-item`](./src/rules/yaml/yaml-no-unused-catalog-item.ts) - Disallow unused catalog items
 - [`yaml-no-duplicate-catalog-item`](./src/rules/yaml/yaml-no-duplicate-catalog-item.ts) - Disallow duplicate catalog items
+- [`yaml-no-anonymous-catalog`](./src/rules/yaml/yaml-no-anonymous-catalog.ts) - Disallow the anonymous `catalog:` in favor of named catalogs (opt-in)
 - [`yaml-valid-packages`](./src/rules/yaml/yaml-valid-packages.ts) - Ensure package patterns match directories with package.json
 - [`yaml-enforce-settings`](./src/rules/yaml/yaml-enforce-settings.ts) - Enforce settings in `pnpm-workspace.yaml`
 

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/index.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/index.ts
@@ -1,4 +1,5 @@
 import enforceSettings from './yaml-enforce-settings'
+import noAnonymousCatalog from './yaml-no-anonymous-catalog'
 import noDuplicateCatalogItem from './yaml-no-duplicate-catalog-item'
 import noUnusedCatalogItem from './yaml-no-unused-catalog-item'
 import validPackages from './yaml-valid-packages'
@@ -6,6 +7,7 @@ import validPackages from './yaml-valid-packages'
 export const rules = {
   'yaml-no-unused-catalog-item': noUnusedCatalogItem,
   'yaml-no-duplicate-catalog-item': noDuplicateCatalogItem,
+  'yaml-no-anonymous-catalog': noAnonymousCatalog,
   'yaml-valid-packages': validPackages,
   'yaml-enforce-settings': enforceSettings,
 }

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-anonymous-catalog.test.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-anonymous-catalog.test.ts
@@ -1,0 +1,73 @@
+import type { InvalidTestCase, ValidTestCase } from 'eslint-vitest-rule-tester'
+import yaml from 'yaml'
+import { runYaml } from '../../utils/_test'
+import rule, { RULE_NAME } from './yaml-no-anonymous-catalog'
+
+const valids: ValidTestCase[] = [
+  // Named catalogs only
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      catalogs: {
+        prod: { vue: '^3.0.0' },
+        dev: { vitest: '^3.0.0' },
+      },
+    }),
+  },
+  // `catalogs.default` is already the named syntax
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      catalogs: {
+        default: { vue: '^3.0.0' },
+      },
+    }),
+  },
+  // No catalogs at all
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      packages: ['packages/*'],
+    }),
+  },
+]
+
+const invalids: InvalidTestCase[] = [
+  // Default catalog alone
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      catalog: { vue: '^3.0.0' },
+    }),
+    errors: [{ messageId: 'unexpectedAnonymousCatalog' }],
+  },
+  // Alongside named catalogs - one report, not one per entry
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      catalog: {
+        vue: '^3.0.0',
+        vitest: '^3.0.0',
+      },
+      catalogs: {
+        prod: { react: '^19.0.0' },
+      },
+    }),
+    errors: [{ messageId: 'unexpectedAnonymousCatalog' }],
+  },
+  // Empty default catalog is still the wrong syntax
+  {
+    filename: 'pnpm-workspace.yaml',
+    code: yaml.stringify({
+      catalog: {},
+    }),
+    errors: [{ messageId: 'unexpectedAnonymousCatalog' }],
+  },
+]
+
+runYaml({
+  name: RULE_NAME,
+  rule,
+  valid: valids,
+  invalid: invalids,
+})

--- a/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-anonymous-catalog.ts
+++ b/packages/eslint-plugin-pnpm/src/rules/yaml/yaml-no-anonymous-catalog.ts
@@ -1,0 +1,56 @@
+import { basename, normalize } from 'pathe'
+import { isMap, isScalar } from 'yaml'
+import { createEslintRule } from '../../utils/create'
+import { getPnpmWorkspace } from '../../utils/workspace'
+
+export const RULE_NAME = 'yaml-no-anonymous-catalog'
+export type MessageIds = 'unexpectedAnonymousCatalog'
+export type Options = []
+
+export default createEslintRule<Options, MessageIds>({
+  name: RULE_NAME,
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow the anonymous `catalog:` in `pnpm-workspace.yaml` in favor of named catalogs',
+    },
+    schema: [],
+    messages: {
+      unexpectedAnonymousCatalog: 'Avoid the anonymous `catalog:`. Use a named catalog (`catalogs: <name>:`) instead.',
+    },
+  },
+  defaultOptions: [],
+  create(context) {
+    if (basename(context.filename) !== 'pnpm-workspace.yaml')
+      return {}
+
+    const workspace = getPnpmWorkspace(context)
+    if (!workspace || normalize(workspace.filepath) !== normalize(context.filename))
+      return {}
+
+    if (workspace.hasChanged() || workspace.hasQueue())
+      return {}
+
+    workspace.setContent(context.sourceCode.text)
+
+    const contents = workspace.getDocument().contents
+    if (!isMap(contents))
+      return {}
+
+    // Report on the key node so the error points at `catalog:` rather than the
+    // whole block. An empty `catalog:` is still flagged - it's the wrong syntax.
+    const key = contents.items.find(item => isScalar(item.key) && item.key.value === 'catalog')?.key
+    if (!isScalar(key) || !key.range)
+      return {}
+
+    context.report({
+      loc: {
+        start: context.sourceCode.getLocFromIndex(key.range[0]),
+        end: context.sourceCode.getLocFromIndex(key.range[1]),
+      },
+      messageId: 'unexpectedAnonymousCatalog',
+    })
+
+    return {}
+  },
+})


### PR DESCRIPTION
## What

Adds an opt-in YAML rule that reports pnpm's anonymous top-level `catalog:` key in `pnpm-workspace.yaml`, for workspaces that standardise on named catalogs.

```yaml
# reported
catalog:
  vue: ^3.0.0

# fine
catalogs:
  prod:
    vue: ^3.0.0
```

`catalogs: default:` is deliberately **not** reported — it is already the named form, even though pnpm resolves bare `catalog:` specifiers to it.

## Notes

- **Not fixable.** Rewriting `catalog:` into `catalogs: <name>:` would silently break every bare `catalog:` specifier across the workspace's `package.json` files, which a YAML-scoped rule can't rewrite reliably. Report-only seemed the honest option.
- **Not enabled in `configs.yaml`** — preferring named catalogs is a style choice, not a correctness one, so it follows `yaml-enforce-settings` in being registered but opt-in.
- Follows the existing YAML rule shape (filename guard → `getPnpmWorkspace` → `hasChanged`/`hasQueue` bail → `setContent`), and reports on the key node so the error lands on `catalog:` rather than the whole block.

## Known interaction worth flagging

`json-enforce-catalog` defaults `defaultCatalog: 'default'`, and `setPackage` writes `setPath(['catalog', pkg])` when `catalogs.default` is absent ([`pnpm-workspace-yaml/src/index.ts`](https://github.com/antfu/pnpm-workspace-utils/blob/main/packages/pnpm-workspace-yaml/src/index.ts#L145-L154)). So with both rules on, `--fix` can generate the very `catalog:` this rule then reports, with no autofix to undo it.

Setting `defaultCatalog` to a named catalog avoids it, so it is not a blocker — but it's arguably a sign the preference belongs on the write side too. Happy to follow up separately if you think that's worth changing.

## Testing

6 new cases in `yaml-no-anonymous-catalog.test.ts` (named catalogs, `catalogs: default:`, no catalogs; anonymous alone, alongside named, and empty). Full suite green at 87/87, `typecheck` clean, and the rule passes against this repo's own `pnpm-workspace.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)